### PR TITLE
Updating the schedule

### DIFF
--- a/index.html
+++ b/index.html
@@ -189,7 +189,8 @@ eventbrite:           # optional: alphanumeric key for Eventbrite registration, 
       <tr> <td>09:00</td>  <td>Version control with Git</td> </tr>
       <tr> <td>10:30</td>  <td>Coffee</td> </tr>
       <tr> <td>12:00</td>  <td>Lunch break</td> </tr>
-      <tr> <td>13:00</td>  <td>Wrap-up</td> </tr>
+      <tr> <td>13:00</td>  <td>Structured programming with Python</td> </tr>
+      <tr> <td>16:00</td>  <td>Wrap-up and close</td> </tr>
     </table>
   </div>
 </div>


### PR DESCRIPTION
The standard SWC workshop covers Python in two sessions. @ andre-geldenhuis can you clarify if you are planning on 2 full days? This would also help retain the GNS audience.
