### PR TITLE
added live link to windows nano SWCinstaller

### DIFF
--- a/index.html
+++ b/index.html
@@ -507,7 +507,7 @@ eventbrite:     26939323241
       <p>
         nano is a basic editor and the default that instructors use in the workshop.
         To install it,
-        download the <a href="{{site.swc_installer}}">Software Carpentry Windows installer</a>
+        download the <a href="https://github.com/swcarpentry/windows-installer/releases/download/v0.3/SWCarpentryInstaller.exe">Software Carpentry Windows installer</a>
         and double click on the file to run it.
         <strong>This installer requires an active internet connection.</strong>
       </p>


### PR DESCRIPTION
not really sure what {{site.swc_installer}} was supposed to be doing, but it would just redirect to the same page. forgive my ignorance on this one.
